### PR TITLE
Surface ElvID H2 validation at plan time via /api/ApiScope/validate

### DIFF
--- a/internal/elvidapiclient/apiscopeservice.go
+++ b/internal/elvidapiclient/apiscopeservice.go
@@ -37,6 +37,30 @@ func CreateOrUpdateApiScope(ctx context.Context, elvidAuthority string, accessTo
 	return &apiScope, nil
 }
 
+// ValidateNewApiScope dry-runs the create-time validation server-side without
+// persisting anything. Used by ApiScopeResource.ModifyPlan so naming-convention
+// and AD-group-existence errors surface in the speculative plan on a PR instead
+// of mid-apply on merge. See ADR 2026-05-CORE-2650 (H2) in the elvid repo.
+func ValidateNewApiScope(ctx context.Context, elvidAuthority string, accessTokenAD string, apiScopeDto *ApiScopeDto) error {
+	apiUrl := fmt.Sprintf("%s/api/ApiScope/validate", elvidAuthority)
+
+	apiScopeAsJson, err := json.Marshal(apiScopeDto)
+	if err != nil {
+		return err
+	}
+
+	response, err := PostRequest(ctx, apiUrl, accessTokenAD, apiScopeAsJson)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode == 200 {
+		return nil
+	}
+	return ElvidErrorResponse(response, apiUrl)
+}
+
 func ReadApiScope(ctx context.Context, elvidAuthority string, accessTokenAD string, name string) (*ApiScopeDto, error) {
 	if name == "" {
 		return nil, errors.New("no name provided in ReadApiScope")

--- a/internal/elvidapiclient/apiscopeservice_test.go
+++ b/internal/elvidapiclient/apiscopeservice_test.go
@@ -1,0 +1,71 @@
+package elvidapiclient
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Minimal coverage of ValidateNewApiScope, the new client function powering
+// ApiScopeResource.ModifyPlan (plan-time H2 enforcement). Catches the most
+// realistic regression: a typo in the URL path or a wrong status-code branch
+// silently disabling plan-time validation. The wider provider test suite is
+// deliberately out of scope — see the discussion in elvid PR #833.
+
+func TestValidateNewApiScope_Success_ReturnsNil(t *testing.T) {
+	var receivedPath, receivedMethod string
+	var receivedBody string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		receivedMethod = r.Method
+		b, _ := io.ReadAll(r.Body)
+		receivedBody = string(b)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	err := ValidateNewApiScope(context.Background(), server.URL, "fake-token", &ApiScopeDto{
+		Name:                "convey.api.test",
+		AllowMachineClients: true,
+	})
+
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if receivedPath != "/api/ApiScope/validate" {
+		t.Errorf("expected POST to /api/ApiScope/validate, got %s", receivedPath)
+	}
+	if receivedMethod != http.MethodPost {
+		t.Errorf("expected POST, got %s", receivedMethod)
+	}
+	if !strings.Contains(receivedBody, `"convey.api.test"`) {
+		t.Errorf("expected DTO JSON in body, got: %s", receivedBody)
+	}
+}
+
+func TestValidateNewApiScope_BadRequest_ReturnsErrorWithBody(t *testing.T) {
+	const elvidMessage = "AD group 'systemaccess-foo-developer' does not exist. Create the group first ... See ADR 2026-05-CORE-2650 (H2)."
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(elvidMessage))
+	}))
+	defer server.Close()
+
+	err := ValidateNewApiScope(context.Background(), server.URL, "fake-token", &ApiScopeDto{
+		Name:                "foo.bar",
+		AllowMachineClients: true,
+	})
+
+	if err == nil {
+		t.Fatal("expected error on 400 response, got nil")
+	}
+	// The error wraps the response body; Terraform shows this in the plan output.
+	if !strings.Contains(err.Error(), elvidMessage) {
+		t.Errorf("expected error to contain ElvID's message, got: %v", err)
+	}
+}

--- a/internal/provider/resource_apiscope.go
+++ b/internal/provider/resource_apiscope.go
@@ -83,6 +83,41 @@ func (r *ApiScopeResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 	}
 }
 
+// ModifyPlan runs ElvID's server-side H2 validation against the planned values
+// at plan time, so naming-convention and AD-group-existence errors surface in
+// the PR's speculative plan instead of mid-apply on merge. We only validate on
+// create (state is null); updates and deletes go through their own checks at
+// apply. See ADR 2026-05-CORE-2650 (H2) in the elvid repo.
+func (r *ApiScopeResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	// Plan removal (delete) — nothing to validate.
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+	// Update — H2 only applies on create; server's validate endpoint no-ops if
+	// the scope name already exists, but skip the call entirely to keep plans fast
+	// and offline-resilient for the common case.
+	if !req.State.Raw.IsNull() {
+		return
+	}
+	// Provider not yet configured (e.g. terraform validate without auth) — skip
+	// the call rather than hard-fail; the apply will still enforce.
+	if providerInput == nil || providerInput.AccessTokenAD == "" {
+		return
+	}
+
+	var plan ApiScopeResource
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	dto := plan.DtoFromApiScopeResource()
+	if err := elvidapiclient.ValidateNewApiScope(ctx, providerInput.ElvIDAuthority, providerInput.AccessTokenAD, dto); err != nil {
+		resp.Diagnostics.AddError("ApiScope plan-time validation failed", err.Error())
+	}
+}
+
 func (r *ApiScopeResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan ApiScopeResource
 	diags := req.Plan.Get(ctx, &plan)


### PR DESCRIPTION
**Depends on**: a new `POST /api/ApiScope/validate` endpoint in the elvid repo (PR `CORE-2650-validate-endpoint`). Merge that first.

## Problem

The elvid H2 enforcement (naming convention + AD-group existence — ADR 2026-05-CORE-2650 in the elvid repo) only ran on the actual `POST /api/ApiScope` call, which happens during `terraform apply`. So a PR in `elvid-apiscope-terraform` adding a rootless scope passed the speculative plan and only broke on merge, after reviewers had approved it.

## Fix

`ApiScopeResource.ModifyPlan` now dry-runs H2 against the server's new `/api/ApiScope/validate` endpoint. Errors surface in the PR's speculative plan with the same message the apply would produce:

```
ApiScope plan-time validation failed: ElvID returned StatusCode 400 ... message:
AD group 'systemaccess-foo-developer' does not exist. Create the group first
so its members can approve scopes for system 'foo'. See ADR 2026-05-CORE-2650 (H2).
```

Only fires on create (state is null) — updates and deletes skip the call to keep plans fast and the server endpoint no-ops anyway on existing scopes.

## Trade-offs

This adds a network call to plan time, which is mildly unidiomatic for Terraform providers (plan is usually offline-friendly). Accepted because:
- The provider already makes API calls in Read (so plans already need auth + the server)
- The H2 check requires a Graph lookup that can't be expressed as a static schema validator
- For an internal provider, DX (catching bad scopes at PR time) outweighs the offline-purity argument

## Verification

Open a follow-up PR in `elvid-apiscope-terraform` adding a scope with a non-existent system prefix; the speculative plan should fail with the H2 message instead of passing.